### PR TITLE
Explicitly Grant Permissions

### DIFF
--- a/.github/workflows/DocTagChecker.yml
+++ b/.github/workflows/DocTagChecker.yml
@@ -10,7 +10,7 @@ jobs:
         BRANCH_NAME: ${{ github.head_ref || github.ref_name }} 
     permissions:
       # needed to grant workflows opened by dependabot rights to create comments.
-      issues: read|write
+      issues: write
       pull-requests: read
     steps:
       - name: Checkout

--- a/.github/workflows/DocTagChecker.yml
+++ b/.github/workflows/DocTagChecker.yml
@@ -11,17 +11,17 @@ jobs:
     # needed to grant workflows opened by dependabot rights to create comments.
     permissions:
       issues: write
-      actions: write
-      checks: write
-      contents: write
-      deployments: write
-      id-token: write
-      discussions: write
-      packages: write
-      pages: write
-      repository-projects: write
-      security-events: write
-      statuses: write
+      # actions: write
+      # checks: write
+      # contents: write
+      # deployments: write
+      # id-token: write
+      # discussions: write
+      # packages: write
+      # pages: write
+      # repository-projects: write
+      # security-events: write
+      # statuses: write
       pull-requests: write
     steps:
       - name: Checkout

--- a/.github/workflows/DocTagChecker.yml
+++ b/.github/workflows/DocTagChecker.yml
@@ -8,10 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     env:
         BRANCH_NAME: ${{ github.head_ref || github.ref_name }} 
+    # needed to grant workflows opened by dependabot rights to create comments.
     permissions:
-      # needed to grant workflows opened by dependabot rights to create comments.
       issues: write
       discussions: write
+      contents: write
       pull-requests: read
     steps:
       - name: Checkout

--- a/.github/workflows/DocTagChecker.yml
+++ b/.github/workflows/DocTagChecker.yml
@@ -10,8 +10,9 @@ jobs:
         BRANCH_NAME: ${{ github.head_ref || github.ref_name }} 
     permissions:
       # needed to grant workflows opened by dependabot rights to create comments.
-      issues: write
-      pull-requests: read
+      # issues: write
+      # pull-requests: read
+      write-all
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/DocTagChecker.yml
+++ b/.github/workflows/DocTagChecker.yml
@@ -15,6 +15,8 @@ jobs:
       contents: write
       actions: write
       checks: write
+      packages: write
+      repository-projects: write
       pull-requests: read
     steps:
       - name: Checkout

--- a/.github/workflows/DocTagChecker.yml
+++ b/.github/workflows/DocTagChecker.yml
@@ -15,7 +15,7 @@ jobs:
       checks: write
       contents: write
       deployments: write
-      id-tokens: write
+      id-token: write
       discussions: write
       packages: write
       pages: write

--- a/.github/workflows/DocTagChecker.yml
+++ b/.github/workflows/DocTagChecker.yml
@@ -8,6 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     env:
         BRANCH_NAME: ${{ github.head_ref || github.ref_name }} 
+    permissions:
+      # needed to grant workflows opened by dependabot rights to create comments.
+      issues: write
+      pull-requests: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/DocTagChecker.yml
+++ b/.github/workflows/DocTagChecker.yml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       # needed to grant workflows opened by dependabot rights to create comments.
       issues: write
+      discussions: write
       pull-requests: read
     steps:
       - name: Checkout

--- a/.github/workflows/DocTagChecker.yml
+++ b/.github/workflows/DocTagChecker.yml
@@ -10,7 +10,7 @@ jobs:
         BRANCH_NAME: ${{ github.head_ref || github.ref_name }} 
     # needed to grant workflows opened by dependabot rights to create comments.
     permissions:
-      issues: write
+      # issues: write
       # actions: write
       # checks: write
       # contents: write

--- a/.github/workflows/DocTagChecker.yml
+++ b/.github/workflows/DocTagChecker.yml
@@ -10,9 +10,8 @@ jobs:
         BRANCH_NAME: ${{ github.head_ref || github.ref_name }} 
     permissions:
       # needed to grant workflows opened by dependabot rights to create comments.
-      read-all
-      issues: write
-      # pull-requests: read
+      issues: read|write
+      pull-requests: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/DocTagChecker.yml
+++ b/.github/workflows/DocTagChecker.yml
@@ -8,20 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
         BRANCH_NAME: ${{ github.head_ref || github.ref_name }} 
-    # needed to grant workflows opened by dependabot rights to create comments.
     permissions:
-      # issues: write
-      # actions: write
-      # checks: write
-      # contents: write
-      # deployments: write
-      # id-token: write
-      # discussions: write
-      # packages: write
-      # pages: write
-      # repository-projects: write
-      # security-events: write
-      # statuses: write
+      # needed to grant workflows opened by dependabot rights to create comments.
       pull-requests: write
     steps:
       - name: Checkout

--- a/.github/workflows/DocTagChecker.yml
+++ b/.github/workflows/DocTagChecker.yml
@@ -22,7 +22,7 @@ jobs:
       repository-projects: write
       security-events: write
       statuses: write
-      pull-requests: read
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/DocTagChecker.yml
+++ b/.github/workflows/DocTagChecker.yml
@@ -17,6 +17,7 @@ jobs:
       checks: write
       packages: write
       repository-projects: write
+      security-events: write
       pull-requests: read
     steps:
       - name: Checkout

--- a/.github/workflows/DocTagChecker.yml
+++ b/.github/workflows/DocTagChecker.yml
@@ -18,6 +18,7 @@ jobs:
       packages: write
       repository-projects: write
       security-events: write
+      statuses: write
       pull-requests: read
     steps:
       - name: Checkout

--- a/.github/workflows/DocTagChecker.yml
+++ b/.github/workflows/DocTagChecker.yml
@@ -13,6 +13,8 @@ jobs:
       issues: write
       discussions: write
       contents: write
+      actions: write
+      checks: write
       pull-requests: read
     steps:
       - name: Checkout

--- a/.github/workflows/DocTagChecker.yml
+++ b/.github/workflows/DocTagChecker.yml
@@ -10,9 +10,9 @@ jobs:
         BRANCH_NAME: ${{ github.head_ref || github.ref_name }} 
     permissions:
       # needed to grant workflows opened by dependabot rights to create comments.
-      # issues: write
+      read-all
+      issues: write
       # pull-requests: read
-      write-all
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/DocTagChecker.yml
+++ b/.github/workflows/DocTagChecker.yml
@@ -11,11 +11,14 @@ jobs:
     # needed to grant workflows opened by dependabot rights to create comments.
     permissions:
       issues: write
-      discussions: write
-      contents: write
       actions: write
       checks: write
+      contents: write
+      deployments: write
+      id-tokens: write
+      discussions: write
       packages: write
+      pages: write
       repository-projects: write
       security-events: write
       statuses: write


### PR DESCRIPTION
When a user like dependabot starts the DocTagChecker workflow they don't pass sufficient rights to the action to post messages to PRs via their GitHubToken.

This PR fixes this by setting the permissions of the job explicitly.